### PR TITLE
Wrong app-mode initialization in case of an exception

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ include $(BOLOS_SDK)/Makefile.defines
 APPNAME      = "Shimmer"
 APPVERSION_M = 0
 APPVERSION_N = 8
-APPVERSION_P = 0
+APPVERSION_P = 1
 APPVERSION   = "$(APPVERSION_M).$(APPVERSION_N).$(APPVERSION_P)"
 
 APP_LOAD_PARAMS = --path "44'/1'" --curve ed25519 --appFlags 0x240 $(COMMON_LOAD_PARAMS)

--- a/Makefile
+++ b/Makefile
@@ -144,4 +144,4 @@ include $(BOLOS_SDK)/Makefile.rules
 dep/%.d: %.c Makefile
 
 listvariants:
-	@echo VARIANTS COIN iota
+	@echo VARIANTS COIN shimmer

--- a/src/main.c
+++ b/src/main.c
@@ -110,7 +110,7 @@ static void IOTA_main()
                     break;
                 default:
                     // reset states and UI
-                    api_initialize(APP_MODE_IOTA_CHRYSALIS, 0);
+                    api_initialize(APP_MODE_INIT, 0);
                     ui_reset();
                 }
 


### PR DESCRIPTION
The app was initialized with the wrong app mode in case of an exception.

The result was that another exception was thrown in the catch block and the app crashes.