### PR TITLE
fixed missing trailing zeros on amount smaller than 0.1smr 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ include $(BOLOS_SDK)/Makefile.defines
 APPNAME      = "Shimmer"
 APPVERSION_M = 0
 APPVERSION_N = 8
-APPVERSION_P = 1
+APPVERSION_P = 2
 APPVERSION   = "$(APPVERSION_M).$(APPVERSION_N).$(APPVERSION_P)"
 
 APP_LOAD_PARAMS = --path "44'/1'" --curve ed25519 --appFlags 0x240 $(COMMON_LOAD_PARAMS)
@@ -71,6 +71,9 @@ else
     DEFINES += HAVE_BAGL_FONT_OPEN_SANS_EXTRABOLD_11PX
     DEFINES += HAVE_BAGL_FONT_OPEN_SANS_LIGHT_16PX
 endif
+
+# default disable DEBUG build
+DEBUG = 0
 
 # if speculos simulator is selected enable debuging features
 ifeq ($(SPECULOS), 1)

--- a/src/ui/ui_common.c
+++ b/src/ui/ui_common.c
@@ -105,7 +105,7 @@ void format_value_full_decimals(char *s, const unsigned int n,
 
     // format 0,xxxxxx
     if (val < 1000000ull) {
-        snprintf(s, n, "0.%06u", (uint32_t) val);
+        snprintf(s, n, "0.%06u", (uint32_t)val);
         return;
     }
 

--- a/src/ui/ui_common.c
+++ b/src/ui/ui_common.c
@@ -105,7 +105,7 @@ void format_value_full_decimals(char *s, const unsigned int n,
 
     // format 0,xxxxxx
     if (val < 1000000ull) {
-        snprintf(s, n, "0.%s", buffer);
+        snprintf(s, n, "0.%06u", (uint32_t) val);
         return;
     }
 


### PR DESCRIPTION
On small amounts below 1SMR the value was formatted as string without leading zero.

For this reason, on small amounts below 0.1SMR leading zeros were missing, showing the value wrong on the display.

